### PR TITLE
Update Form1.cs

### DIFF
--- a/DAWRPC/Form1.cs
+++ b/DAWRPC/Form1.cs
@@ -419,6 +419,7 @@ namespace DAWRPC
                         if (client != null)
                         {
                             client.Dispose();
+                            currentDAWName = DAWName.Text;
                         }
                     }
                 }


### PR DESCRIPTION
Added line to update "currentDAWName" on client disposal. Fixes a bug where opening, closing, and opening the same DAW again breaks rich presence functionality until DAWRPC is restarted or different DAW is opened.